### PR TITLE
Local only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-OBJ := build/wails-flatpak
+APP := wails-flatpak
+ID := com.ianmjones.$(APP)
+BIN := build/$(APP)
 BACKEND_SRC := $(wildcard *.go)
 FRONTEND_SRC := \
 	$(wildcard frontend/*.js) \
@@ -6,28 +8,29 @@ FRONTEND_SRC := \
 	$(wildcard frontend/public/*.*) \
 	$(wildcard frontend/src/*.*) \
 	$(wildcard frontend/src/components/*.svelte)
+FLATPAK_MANIFEST := $(ID).yml
 
 .PHONY: tgz flatpak run-flatpak install-flatpak clean clean-all
 
-$(OBJ): $(BACKEND_SRC) $(FRONTEND_SRC)
+$(BIN): $(BACKEND_SRC) $(FRONTEND_SRC)
 	wails build
 
-tgz: wails-flatpak.tgz
+tgz: $(APP).tgz
 
-wails-flatpak.tgz: $(OBJ)
+$(APP).tgz: $(BIN)
 	tar -C build -czvf $@ $(^F)
 
-flatpak: com.ianmjones.wails-flatpak.yml $(OBJ)
+flatpak: $(FLATPAK_MANIFEST) $(BIN)
 	flatpak-builder .flatpak-tmp $< --force-clean
 
-run-flatpak: com.ianmjones.wails-flatpak.yml $(OBJ) flatpak
-	flatpak-builder --run .flatpak-tmp $< wails-flatpak
+run-flatpak: $(FLATPAK_MANIFEST) $(BIN) flatpak
+	flatpak-builder --run .flatpak-tmp $< $(APP)
 
-install-flatpak: com.ianmjones.wails-flatpak.yml $(OBJ)
+install-flatpak: $(FLATPAK_MANIFEST) $(BIN)
 	flatpak-builder .flatpak-tmp $< --user --install --force-clean
 
 clean:
-	rm -rf wails-flatpak.tgz build frontend/public/build .flatpak-tmp
+	rm -rf $(APP).tgz build frontend/public/build .flatpak-tmp
 
 clean-all: clean
 	rm -rf frontend/node_modules .flatpak-builder

--- a/com.ianmjones.wails-flatpak.yml
+++ b/com.ianmjones.wails-flatpak.yml
@@ -13,9 +13,7 @@ modules:
   - name: wails-flatpak
     buildsystem: simple
     build-commands:
-      - install -D wails-flatpak /app/bin/wails-flatpak
+      - install -D build/wails-flatpak /app/bin/wails-flatpak
     sources:
-      - type: archive
-        url: https://github.com/ianmjones/wails-flatpak/releases/download/0.1/wails-flatpak.tar.gz
-        sha256: "ac7c3093f684ffef2407292a70747240cfced2544d7b7fd5d742fbaa5348e4d2"
-        strip-components: 0
+      - type: dir
+        path: .


### PR DESCRIPTION
Switch back to using local binary in flatpak manifest.

A remote source would only really be useful when creating a manifest specifically for a flatpak remote repo, e.g. FlatHub. And in that case, you would create the manifest in their preferred location, e.g. in a github.com/flathub/ repo.

Also, I made the Makefile a little more reusable. 😉